### PR TITLE
Removed axes() because not defined

### DIFF
--- a/julia.ipynb
+++ b/julia.ipynb
@@ -47,7 +47,6 @@
    "source": [
     "#  Scatterplot\n",
     "fig = figure(\"scatterplot\",figsize=(10,10))\n",
-    "ax = axes()\n",
     "scatter(x,y,s=areas,alpha=0.5, c=areas)\n",
     "\n",
     "title(\"Scatter Plot\")\n",


### PR DESCRIPTION
I got the following error when I tried to run this notebook through binder. Not very experienced with Julia so sure what the problem is...
'''
UndefVarError: axes not defined

Stacktrace:
 [1] include_string(::String, ::String) at ./loading.jl:522
 [2] execute_request(::ZMQ.Socket, ::IJulia.Msg) at /srv/julia/pkg/v0.6/IJulia/src/execute_request.jl:193
 [3] (::Compat.#inner#6{Array{Any,1},IJulia.#execute_request,Tuple{ZMQ.Socket,IJulia.Msg}})() at /srv/julia/pkg/v0.6/Compat/src/Compat.jl:125
 [4] eventloop(::ZMQ.Socket) at /srv/julia/pkg/v0.6/IJulia/src/eventloop.jl:8
 [5] (::IJulia.##13#16)() at ./task.jl:335
'''

I removed `ax = axes()` and it runs fine since `ax` variable is never called anyways.